### PR TITLE
Add bounding boxes

### DIFF
--- a/src/main/kotlin/de/snowii/extractor/extractors/Blocks.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/Blocks.kt
@@ -135,6 +135,14 @@ class Blocks : Extractor.Extractor {
 
                 stateJson.add("collision_shapes", collisionShapeIdxsJson)
 
+                val outlineShapeIdxsJson = JsonArray()
+                for (box in state.getOutlineShape(EmptyBlockView.INSTANCE, BlockPos.ORIGIN).boundingBoxes) {
+                    val idx = shapes.putIfAbsent(box, shapes.size)
+                    outlineShapeIdxsJson.add(Objects.requireNonNullElseGet(idx) { shapes.size - 1 })
+                }
+
+                stateJson.add("outline_shapes", outlineShapeIdxsJson)
+
                 for (blockEntity in Registries.BLOCK_ENTITY_TYPE) {
                     if (blockEntity.supports(state)) {
                         stateJson.addProperty("block_entity_type", Registries.BLOCK_ENTITY_TYPE.getRawId(blockEntity))


### PR DESCRIPTION
This adds the bounding boxes for every block, which are needed for raycasting and block collisions. They are different from collision boxes: https://minecraft.fandom.com/wiki/Hitbox#Collision_box (Here they call it outline boxes)