### PR TITLE
feat: add instruments

### DIFF
--- a/src/main/kotlin/de/snowii/extractor/Extractor.kt
+++ b/src/main/kotlin/de/snowii/extractor/Extractor.kt
@@ -86,6 +86,7 @@ class Extractor : ModInitializer {
             FlowerPotTransformation(),
             Fuels(),
             RecipeRemainder(),
+            Instruments(),
             ChunkDumpTests.NoiseDump(
                 "no_blend_no_beard_0_0.chunk",
                 0,

--- a/src/main/kotlin/de/snowii/extractor/extractors/Instruments.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/Instruments.kt
@@ -1,0 +1,32 @@
+package de.snowii.extractor.extractors
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.mojang.serialization.JsonOps
+import de.snowii.extractor.Extractor
+import net.minecraft.item.Instrument
+import net.minecraft.registry.RegistryKeys
+import net.minecraft.registry.RegistryOps
+import net.minecraft.server.MinecraftServer
+
+class Instruments : Extractor.Extractor {
+    override fun fileName(): String {
+        return "instruments.json"
+    }
+
+    override fun extract(server: MinecraftServer): JsonElement {
+        val instruments = JsonObject()
+
+        for (instrument in server.registryManager.getOrThrow(RegistryKeys.INSTRUMENT).streamEntries().toList()) {
+            instruments.add(
+                instrument.key.get().value.toString(),
+                Instrument.CODEC.encodeStart(
+                    RegistryOps.of(JsonOps.INSTANCE, server.registryManager),
+                    instrument.value()
+                ).getOrThrow()
+            )
+        }
+
+        return instruments
+    }
+}


### PR DESCRIPTION
Instruments are data structures consisting of a description, a sound event, a sound range and a use duration (the cooldown). Currently only used for goat horns.