### PR TITLE
feat: add block map color support

### DIFF
--- a/src/main/kotlin/de/snowii/extractor/extractors/Blocks.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/Blocks.kt
@@ -78,6 +78,7 @@ class Blocks : Extractor.Extractor {
             blockJson.addProperty("jump_velocity_multiplier", block.jumpFactor)
             blockJson.addProperty("hardness", block.defaultBlockState().getDestroySpeed(EmptyBlockGetter.INSTANCE, BlockPos.ZERO))
             blockJson.addProperty("blast_resistance", block.explosionResistance)
+            blockJson.addProperty("map_color", block.defaultMapColor().id)
             blockJson.addProperty("item_id", BuiltInRegistries.ITEM.getId(block.asItem()))
 
             flammableData[block]?.let { (spreadChance, burnChance) ->


### PR DESCRIPTION
- This is required to add the `map_color` property to Pumpkin's blocks for full map support (which I may or may not be working on rn).

<img width="847" height="473" alt="me holding a working map on a PumpkinMC server" src="https://github.com/user-attachments/assets/c619049d-eca8-4ea5-ae70-570e972c529c" />
