### PR TITLE
chore: add minimum and maximum for integer game rules

### DIFF
--- a/src/main/kotlin/de/snowii/extractor/extractors/GameRules.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/GameRules.kt
@@ -2,6 +2,7 @@ package de.snowii.extractor.extractors
 
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.mojang.brigadier.arguments.IntegerArgumentType
 import de.snowii.extractor.Extractor
 import net.minecraft.core.registries.Registries
 import net.minecraft.server.MinecraftServer
@@ -18,7 +19,16 @@ class GameRules : Extractor.Extractor {
             server.registryAccess().lookupOrThrow(Registries.GAME_RULE)
         for (rule in registry) {
             when (rule.gameRuleType()) {
-                GameRuleType.INT -> gameEventJson.addProperty(rule.toString(), rule.defaultValue() as Int)
+                GameRuleType.INT -> {
+                    val intValues = JsonObject()
+                    intValues.addProperty("default", rule.defaultValue() as Int)
+                    val argument = rule.argument()
+                    if (argument is IntegerArgumentType) {
+                        intValues.addProperty("min", argument.minimum)
+                        intValues.addProperty("max", argument.maximum)
+                    }
+                    gameEventJson.add(rule.toString(), intValues)
+                }
                 GameRuleType.BOOL -> gameEventJson.addProperty(rule.toString(), rule.defaultValue() as Boolean)
             }
         }

--- a/src/main/kotlin/de/snowii/extractor/extractors/Recipes.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/Recipes.kt
@@ -18,7 +18,7 @@ class Recipes : Extractor.Extractor {
         for (recipeRaw in server.recipeManager.recipes) {
             val recipe = recipeRaw.value
             recipesJson.add(
-                recipeRaw.id.value.toString(),
+                recipeRaw.id.identifier().toString(),
                 Recipe.CODEC.encodeStart(
                     JsonOps.INSTANCE,
                     recipe


### PR DESCRIPTION
This PR adds extra information for game rules of an integer type by converting the just default value to a map of a `min`, `max` and `default`.

It also fixes the recipe extraction to not cause errors while compiling.

For example, if the game rule `max_snow_accumulation_height` was mentioned as

```
"max_snow_accumulation_height":1
```

it would now be mentioned as

```
"max_snow_accumulation_height":{"default":1,"min":0,"max":8}
```