### PR TITLE
Update to the extraction of DialogActionType, DialogBodyType, InputControlType, and DialogType

### DIFF
--- a/src/main/kotlin/de/snowii/extractor/extractors/DialogActionType.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/DialogActionType.kt
@@ -1,10 +1,14 @@
 package de.snowii.extractor.extractors
 
+import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.mojang.serialization.JsonOps
 import de.snowii.extractor.Extractor
+import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.core.registries.Registries
 import net.minecraft.server.MinecraftServer
+import org.slf4j.LoggerFactory
 
 class DialogActionType : Extractor.Extractor {
     override fun fileName(): String {
@@ -12,15 +16,25 @@ class DialogActionType : Extractor.Extractor {
     }
 
     override fun extract(server: MinecraftServer): JsonElement {
-        val dialogActionJson = JsonObject()
-        val registry =
-            server.registryAccess().lookupOrThrow(Registries.DIALOG_ACTION_TYPE)
+        val json = JsonObject()
+        val registry = BuiltInRegistries.DIALOG_ACTION_TYPE
 
-        for (dialogType in registry.stream()) {
-            val id = registry.getId(dialogType)
-            dialogActionJson.addProperty(id.toString(), registry.getId(dialogType))
+        for (codec in registry) {
+            val key = registry.getKey(codec) ?: continue
+            val entry = JsonObject()
+            entry.addProperty("id", registry.getId(codec))
+
+            val fields = JsonArray()
+            val seen = LinkedHashSet<String>()
+            codec.keys(JsonOps.INSTANCE)
+                .map { it.asString }
+                .filter { seen.add(it) }
+                .forEach { fields.add(it) }
+            entry.add("fields", fields)
+
+            json.add(key.toString(), entry)
         }
 
-        return dialogActionJson
+        return json
     }
 }

--- a/src/main/kotlin/de/snowii/extractor/extractors/DialogBodyType.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/DialogBodyType.kt
@@ -1,8 +1,11 @@
 package de.snowii.extractor.extractors
 
+import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.mojang.serialization.JsonOps
 import de.snowii.extractor.Extractor
+import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.core.registries.Registries
 import net.minecraft.server.MinecraftServer
 
@@ -12,15 +15,25 @@ class DialogBodyType : Extractor.Extractor {
     }
 
     override fun extract(server: MinecraftServer): JsonElement {
-        val dialogBodyJson = JsonObject()
-        val registry =
-            server.registryAccess().lookupOrThrow(Registries.DIALOG_BODY_TYPE)
+        val json = JsonObject()
+        val registry = BuiltInRegistries.DIALOG_BODY_TYPE
 
-        for (dialogType in registry.stream()) {
-            val id = registry.getId(dialogType)
-            dialogBodyJson.addProperty(id.toString(), registry.getId(dialogType))
+        for (codec in registry) {
+            val key = registry.getKey(codec) ?: continue
+            val entry = JsonObject()
+            entry.addProperty("id", registry.getId(codec))
+
+            val fields = JsonArray()
+            val seen = LinkedHashSet<String>()
+            codec.keys(JsonOps.INSTANCE)
+                .map { it.asString }
+                .filter { seen.add(it) }
+                .forEach { fields.add(it) }
+            entry.add("fields", fields)
+
+            json.add(key.toString(), entry)
         }
 
-        return dialogBodyJson
+        return json
     }
 }

--- a/src/main/kotlin/de/snowii/extractor/extractors/DialogType.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/DialogType.kt
@@ -1,8 +1,11 @@
 package de.snowii.extractor.extractors
 
+import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.mojang.serialization.JsonOps
 import de.snowii.extractor.Extractor
+import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.core.registries.Registries
 import net.minecraft.server.MinecraftServer
 
@@ -12,15 +15,25 @@ class DialogType : Extractor.Extractor {
     }
 
     override fun extract(server: MinecraftServer): JsonElement {
-        val dialogTypeJson = JsonObject()
-        val registry =
-            server.registryAccess().lookupOrThrow(Registries.DIALOG_TYPE)
+        val json = JsonObject()
+        val registry = BuiltInRegistries.DIALOG_TYPE
 
-        for (dialogType in registry.stream()) {
-            val id = registry.getId(dialogType)
-            dialogTypeJson.addProperty(id.toString(), registry.getId(dialogType))
+        for (codec in registry) {
+            val key = registry.getKey(codec) ?: continue
+            val entry = JsonObject()
+            entry.addProperty("id", registry.getId(codec))
+
+            val fields = JsonArray()
+            val seen = LinkedHashSet<String>()
+            codec.keys(JsonOps.INSTANCE)
+                .map { it.asString }
+                .filter { seen.add(it) }
+                .forEach { fields.add(it) }
+            entry.add("fields", fields)
+
+            json.add(key.toString(), entry)
         }
 
-        return dialogTypeJson
+        return json
     }
 }

--- a/src/main/kotlin/de/snowii/extractor/extractors/InputControlType.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/InputControlType.kt
@@ -1,8 +1,11 @@
 package de.snowii.extractor.extractors
 
+import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.mojang.serialization.JsonOps
 import de.snowii.extractor.Extractor
+import net.minecraft.core.registries.BuiltInRegistries
 import net.minecraft.core.registries.Registries
 import net.minecraft.server.MinecraftServer
 
@@ -12,15 +15,25 @@ class InputControlType : Extractor.Extractor {
     }
 
     override fun extract(server: MinecraftServer): JsonElement {
-        val InputControlTypeJson = JsonObject()
-        val registry =
-            server.registryAccess().lookupOrThrow(Registries.INPUT_CONTROL_TYPE)
+        val json = JsonObject()
+        val registry = BuiltInRegistries.INPUT_CONTROL_TYPE
 
-        for (inputControlType in registry.stream()) {
-            val id = registry.getId(inputControlType)
-            InputControlTypeJson.addProperty(id.toString(), registry.getId(inputControlType))
+        for (codec in registry) {
+            val key = registry.getKey(codec) ?: continue
+            val entry = JsonObject()
+            entry.addProperty("id", registry.getId(codec))
+
+            val fields = JsonArray()
+            val seen = LinkedHashSet<String>()
+            codec.keys(JsonOps.INSTANCE)
+                .map { it.asString }
+                .filter { seen.add(it) }
+                .forEach { fields.add(it) }
+            entry.add("fields", fields)
+
+            json.add(key.toString(), entry)
         }
 
-        return InputControlTypeJson
+        return json
     }
 }


### PR DESCRIPTION
Updated the DialogActionType, DialogBodyType, DialogType, and InputControlType extractors to use BuiltInRegistries instead of server.registryAccess().
Each exported entry now includes a list of its fields in addition to its ID to make them more usable.