### PR TITLE
feat: custom stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Extractor is a Fabric mod that extracts Minecraft data (blocks, items, entities,
 - [x] DialogType
 - [x] DialogActionType
 - [x] DialogBodyType
+- [x] Custom Stats
 
 ### Running
 

--- a/src/main/kotlin/de/snowii/extractor/Extractor.kt
+++ b/src/main/kotlin/de/snowii/extractor/Extractor.kt
@@ -87,6 +87,7 @@ class Extractor : ModInitializer {
             Fuels(),
             RecipeRemainder(),
             VillagerData(),
+            CustomStats(),
          /*   ChunkDumpTests.NoiseDump(
                 "no_blend_no_beard_0_0.chunk",
                 0,
@@ -175,7 +176,7 @@ class Extractor : ModInitializer {
             return
         }
 
-        val gson = GsonBuilder().disableHtmlEscaping() .create()
+        val gson = GsonBuilder().disableHtmlEscaping().create()
 
         ServerLifecycleEvents.SERVER_STARTED.register(ServerLifecycleEvents.ServerStarted { server: MinecraftServer ->
             val timeInMillis = measureTimeMillis {

--- a/src/main/kotlin/de/snowii/extractor/extractors/CustomStats.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/CustomStats.kt
@@ -1,0 +1,23 @@
+package de.snowii.extractor.extractors
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import de.snowii.extractor.Extractor
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.server.MinecraftServer
+
+class CustomStats : Extractor.Extractor {
+    override fun fileName(): String {
+        return "custom_stats.json"
+    }
+
+    override fun extract(server: MinecraftServer): JsonElement {
+        val statsObject = JsonArray()
+
+        for (stat in BuiltInRegistries.CUSTOM_STAT) {
+            statsObject.add(stat.path)
+        }
+
+        return statsObject
+    }
+}


### PR DESCRIPTION
Statistics, in Minecraft, are composed of a few statistic types. One of them is '**custom**', a type which contains a collection of generic statistics for each player.
This PR makes all of those custom stats be generated into a new file called `custom_stats.json`, which contains a JSON array of their IDs.

As 1.21.11 is currently the latest version to update this kind of stats, I think it would be optimal to generate them.