### PR TITLE
feat: slot ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Extractor is a Fabric mod that extracts Minecraft data (blocks, items, entities,
 - [x] DialogActionType
 - [x] DialogBodyType
 - [x] Custom Stats
+- [x] Slot Ranges
 
 ### Running
 

--- a/src/main/kotlin/de/snowii/extractor/Extractor.kt
+++ b/src/main/kotlin/de/snowii/extractor/Extractor.kt
@@ -88,6 +88,7 @@ class Extractor : ModInitializer {
             RecipeRemainder(),
             VillagerData(),
             CustomStats(),
+            SlotRanges(),
          /*   ChunkDumpTests.NoiseDump(
                 "no_blend_no_beard_0_0.chunk",
                 0,

--- a/src/main/kotlin/de/snowii/extractor/extractors/non_registry/SlotRanges.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/non_registry/SlotRanges.kt
@@ -1,0 +1,28 @@
+package de.snowii.extractor.extractors.non_registry
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import de.snowii.extractor.Extractor
+import net.minecraft.server.MinecraftServer
+import net.minecraft.world.inventory.SlotRanges
+
+class SlotRanges : Extractor.Extractor {
+    override fun fileName(): String {
+        return "slot_ranges.json"
+    }
+
+    override fun extract(server: MinecraftServer): JsonElement {
+        val slotRanges = JsonObject()
+        for (slotRangeName in SlotRanges.allNames()) {
+            val slotRange = SlotRanges.nameToIds(slotRangeName)!!
+            val intList = slotRange.slots()
+
+            val intArray = JsonArray()
+            intList.forEach { i -> intArray.add(i) }
+
+            slotRanges.add(slotRangeName, intArray)
+        }
+        return slotRanges
+    }
+}


### PR DESCRIPTION
**Slot Ranges** are ranges that have a name and a range of integers (the indices of slots) they refer to. They are meaningful for either a player, an entity, or a container (block). They can refer to one or more slots. Here are some examples of them:
- `container.2` = `[2]`: Refers to *only* the 3<super>rd</super> slot of a container.
- `enderchest.9` = `[209]`: Refers to *only* the 10<super>th</super> slot of a player's ender chest.
- `hotbar.*` = `[0, 1, 2, 3, 4, 5, 6, 7, 8]`: Refers to *all* the 9 slots of a player's hotbar.

I think these could be a great candidate to extract as they might change occasionally between versions, and could be part of a constant-time map.