### PR TITLE
feat: extract configured feature tags

### DIFF
--- a/src/main/kotlin/de/snowii/extractor/extractors/Tags.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/Tags.kt
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import de.snowii.extractor.Extractor
+import net.minecraft.core.registries.Registries
 import net.minecraft.server.MinecraftServer
 import net.minecraft.tags.TagNetworkSerialization
 
@@ -36,6 +37,20 @@ class Tags : Extractor.Extractor {
             }
             tagsJson.add(registryKey.identifier().path, tagGroupTagsJson)
         }
+
+        val configuredFeatures = registryAccess.lookupOrThrow(Registries.CONFIGURED_FEATURE)
+        val configuredFeatureTagsJson = JsonObject()
+        configuredFeatures.listTags().forEach { tag ->
+            val values = JsonArray()
+            tag.forEach { holder ->
+                values.add(holder.unwrapKey().orElseThrow().identifier().path)
+            }
+            configuredFeatureTagsJson.add(tag.key().location().toString(), values)
+        }
+        tagsJson.add(
+            Registries.CONFIGURED_FEATURE.identifier().path,
+            configuredFeatureTagsJson
+        )
 
         return tagsJson
     }


### PR DESCRIPTION
# Description
The tag extractor currently only exports tags that are synced over the network, which excludes configured feature tags. This extracts configured feature tags directly from the server registry and adds them to `tags.json`.

# Testing
I Ran the extractor on 26.2 and confirmed the configured feature tags were included in the generated output.