### PR TITLE
feat: extract block shape offsets

### DIFF
--- a/src/main/kotlin/de/snowii/extractor/extractors/Blocks.kt
+++ b/src/main/kotlin/de/snowii/extractor/extractors/Blocks.kt
@@ -60,6 +60,28 @@ class Blocks : Extractor.Extractor {
         return flammableData
     }
 
+    private fun getShapeOffsetData(block: Block): JsonObject? {
+        val state = block.defaultBlockState()
+        if (!state.hasOffsetFunction()) {
+            return null
+        }
+
+        val maxHorizontal = block.maxHorizontalOffset
+        val maxVertical = block.maxVerticalOffset
+        val originOffset = state.getOffset(BlockPos.ZERO)
+        val offsetType = when (originOffset.y) {
+            0.0 -> "xz"
+            -maxVertical.toDouble() -> "xyz"
+            else -> error("Unknown shape offset function for $block")
+        }
+
+        return JsonObject().apply {
+            addProperty("type", offsetType)
+            addProperty("max_horizontal", maxHorizontal)
+            addProperty("max_vertical", maxVertical)
+        }
+    }
+
     override fun extract(server: MinecraftServer): JsonElement {
         val topLevelJson = JsonObject()
         val blocksJson = JsonArray()
@@ -80,6 +102,10 @@ class Blocks : Extractor.Extractor {
             blockJson.addProperty("blast_resistance", block.explosionResistance)
             blockJson.addProperty("map_color", block.defaultMapColor().id)
             blockJson.addProperty("item_id", BuiltInRegistries.ITEM.getId(block.asItem()))
+
+            getShapeOffsetData(block)?.let {
+                blockJson.add("shape_offset", it)
+            }
 
             flammableData[block]?.let { (spreadChance, burnChance) ->
                 val flammableJson = JsonObject()

--- a/src/main/resources/extractor.accesswidener
+++ b/src/main/resources/extractor.accesswidener
@@ -2,6 +2,8 @@ accessWidener v2 official
 
 accessible method net/minecraft/world/level/block/FireBlock getBurnOdds (Lnet/minecraft/world/level/block/state/BlockState;)I
 accessible method net/minecraft/world/level/block/FireBlock getIgniteOdds (Lnet/minecraft/world/level/block/state/BlockState;)I
+accessible method net/minecraft/world/level/block/state/BlockBehaviour getMaxHorizontalOffset ()F
+accessible method net/minecraft/world/level/block/state/BlockBehaviour getMaxVerticalOffset ()F
 
 accessible method net/minecraft/world/entity/LivingEntity getBaseExperienceReward (Lnet/minecraft/server/level/ServerLevel;)I
 
@@ -41,4 +43,3 @@ accessible method net/minecraft/world/level/levelgen/DensityFunctions$Marker wra
 accessible method net/minecraft/world/level/levelgen/DensityFunctions$Marker type ()Lnet/minecraft/world/level/levelgen/DensityFunctions$Marker$Type;
 accessible method net/minecraft/world/level/levelgen/DensityFunctions$HolderHolder function ()Lnet/minecraft/core/Holder;
 accessible method net/minecraft/world/level/levelgen/NoiseChunk getInterpolatedState ()Lnet/minecraft/world/level/block/state/BlockState;
-accessible method net/minecraft/world/level/chunk/ChunkAccess markPosForPostprocessing (Lnet/minecraft/core/BlockPos;)V


### PR DESCRIPTION
## Description

Pumpkin needs vanilla’s position-based block shape offsets for https://github.com/Pumpkin-MC/Pumpkin/pull/2869. These values were previously written by hand in Pumpkin.

This adds `shape_offset` metadata directly to affected entries in `blocks.json`. The Extractor determines which blocks have an offset function and extracts the offset type, maximum horizontal offset and maximum vertical offset from the vanilla block implementation.

This currently extracts 39 blocks: 34 with XZ offsets and 5 with XYZ offsets. It also correctly extracts special limits such as `0.125` for pointed dripstone and sulfur spikes, and `0.1` vertical offset for small dripleaf.

 I also removed an obsolete access-widener entry for `markPosForPostprocessing`. The method is already public in 26.2 under `markPosForPostProcessing`.